### PR TITLE
Prevent template source comments in dot()

### DIFF
--- a/code/Silvergraph.php
+++ b/code/Silvergraph.php
@@ -208,7 +208,15 @@ class Silvergraph extends CliController {
             "Folders" => $folders
         ));
 
+        // Defend against source_file_comments
+        Config::nest();
+        Config::inst()->update('SSViewer', 'source_file_comments', false);
+
+        // Render the output
         $output = $this->renderWith("Silvergraph");
+
+        // Restore the original configuration
+        Config::unnest();
 
         //Set output as plain text, and strip excess empty lines
         $this->response->addHeader("Content-type", "text/plain");


### PR DESCRIPTION
Turn off template source comments when rendering dot() to prevent dot
syntax errors from the embedded comments.

Resolves #1 
