### PR TITLE
Show many_many_extraFields as an intermediary table

### DIFF
--- a/templates/Silvergraph.ss
+++ b/templates/Silvergraph.ss
@@ -34,7 +34,7 @@ edge [
 		        "$Name" [
 		        label = <
 		        <table border="0" cellborder="1" cellspacing="0" cellpadding="4">
-			        <tr><td colspan="2" bgcolor="#d4d6d8"><font face="Helvetica Bold">$Name</font><font face="Helvetica"> (many_many)</font></td></tr>
+			        <tr><td colspan="2" border="0">$Name (many_many)</td></tr>
                     <% loop ExtraFields %>
 				        <tr>
 					        <td><font face="Helvetica Bold">$FieldName</font></td>

--- a/templates/Silvergraph.ss
+++ b/templates/Silvergraph.ss
@@ -29,6 +29,23 @@ edge [
                 </table>
                 >
         ];
+        <% loop ManyMany %>
+            <% if ExtraFields %>
+		        "$Name" [
+		        label = <
+		        <table border="0" cellborder="1" cellspacing="0" cellpadding="4">
+			        <tr><td colspan="2" bgcolor="#d4d6d8"><font face="Helvetica Bold">$Name</font><font face="Helvetica"> (many_many)</font></td></tr>
+                    <% loop ExtraFields %>
+				        <tr>
+					        <td><font face="Helvetica Bold">$FieldName</font></td>
+					        <td><font face="Helvetica Italic">$DataType</font></td>
+				        </tr>
+                    <% end_loop %>
+		        </table>
+		        >
+		        ];
+            <% end_if %>
+        <% end_loop %>
     <% end_loop %>
     <% if Group %>}<% end_if %>
 <% end_loop %>
@@ -54,7 +71,12 @@ edge [
 
         <% if ManyMany %>
         <% loop ManyMany %>
-            "$Up.ClassName" -> "$RemoteClass"[label="$Name (many_many)" dir=both];
+            <% if $ExtraFields %>
+	            "$Name" -> "$RemoteClass";
+	            "$Name" -> "$Up.ClassName";
+            <% else %>
+                "$Up.ClassName" -> "$RemoteClass"[label="$Name (many_many)" dir=both];
+            <% end_if %>
         <% end_loop %>
         <% end_if %>
     <% end_loop %>


### PR DESCRIPTION
There isn't currently a way to visualise extra fields on many-many relationships.

My approach does have the downside of looking a bit like a Class, but I've tried to distinguish it a bit by removing the blue text and adding (many_many). This could probably be improved upon further.

Many-many relationships without any extra fields are unchanged.