### PR TITLE
Drop silverstripe/cms dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
 
     "require":
     {
-	"silverstripe/cms": "~3.0",
 	"silverstripe/framework": "~3.0"
     }
 }


### PR DESCRIPTION
This is the problem that triggered my pull requests :)

Sometimes I use the framework without the CMS and actually this is the case: I am happily using froog/silvergraph (well, at least in the last 30 minutes) without any CMS modules installed. The problem is I had to manually install it because `composer` pulls in the whole CMS stuff.